### PR TITLE
Allow p5.js fullscreen(true) to work

### DIFF
--- a/p5js/js/electron/main.js
+++ b/p5js/js/electron/main.js
@@ -7,6 +7,7 @@ const createWindow = () => {
     height: 400,
     show: false,
     fullscreen: process.env.PRESENT == "true",
+    fullscreenable: true,
     autoHideMenuBar: true,
     alwaysOnTop: false,
     webPreferences: {


### PR DESCRIPTION
Resolves https://github.com/processing/processing-p5.js-mode/issues/21

Now `fullscreen(true)` in a p5 script will work!


https://github.com/user-attachments/assets/07f7178d-baba-49e6-863d-126005615d97

